### PR TITLE
[GH73] Have distribution charts show for points with no current items

### DIFF
--- a/lib/static/static/js/services/cycleTimeService.js
+++ b/lib/static/static/js/services/cycleTimeService.js
@@ -114,11 +114,12 @@
 
             for (var i = 0; i < pointsLabelsToRetrieve.length; i++) {
                 var issuesWithLabel = issueService.getIssuesWithLabel(historicalIssues, 'points: ' + pointsLabelsToRetrieve[i]);
-                var historicalInProgressCycleTimes = getCycleTimesForColumn(issuesWithLabel, '2 - In Progress')
+                var historicalInProgressCycles = getCycleTimesForColumn(issuesWithLabel, '2 - In Progress')
                     .filter(hasValidCycleTime)
-                    .map(getTimeFromCycleInDays);
+                    .map(getCycleInDays)
+                    .sort(sortCycles);
 
-                if (historicalInProgressCycleTimes.length < 2)
+                if (historicalInProgressCycles.length < 2)
                     continue;
 
                 var currentIssuesWithLabel = issueService.getIssuesWithLabel(currentMilestoneIssues, 'points: ' + pointsLabelsToRetrieve[i]);                
@@ -126,19 +127,20 @@
                     .filter(hasValidCycleTime)
                     .map(getCycleInDays);
 
-                if (currentInProgressTimes.length > 0) {
-                    var mean = jStat.mean(historicalInProgressCycleTimes);
-                    var standardDeviation = jStat.stdev(historicalInProgressCycleTimes);
-                    maxValues.push(mean + (3 * standardDeviation));
+                var historicalInProgressCycleTimes = historicalInProgressCycles.map(getTimeFromCycle);
+                var mean = jStat.mean(historicalInProgressCycleTimes);
+                var standardDeviation = jStat.stdev(historicalInProgressCycleTimes);
+                maxValues.push(mean + (3 * standardDeviation));
 
-                    statistics.push({
-                        pointsLabel: pointsLabelsToRetrieve[i],
-                        numberOfHistoricalItems: historicalInProgressCycleTimes.length,
-                        dataPoints: currentInProgressTimes,
-                        mean: mean,
-                        standardDeviation: standardDeviation
-                    });
-                }
+                statistics.push({
+                    pointsLabel: pointsLabelsToRetrieve[i],
+                    numberOfHistoricalItems: historicalInProgressCycleTimes.length,
+                    shortestDataPoint: historicalInProgressCycles[0],
+                    longestDataPoint: historicalInProgressCycles[historicalInProgressCycleTimes.length - 1],
+                    dataPoints: currentInProgressTimes,
+                    mean: mean,
+                    standardDeviation: standardDeviation
+                });
             }
 
             return  {
@@ -151,13 +153,17 @@
             return cycleTime.time > 0;
         }
 
-        function getTimeFromCycleInDays(cycleTime) {
-            return dateService.toDays(cycleTime.time);
+        function getTimeFromCycle(cycleTime) {
+            return cycleTime.time;
         }
 
         function getCycleInDays(cycleTime) {
             cycleTime.time = dateService.toDays(cycleTime.time);
             return cycleTime;
+        }
+
+        function sortCycles(cycleOne, cycleTwo) {
+            return cycleOne.time - cycleTwo.time;
         }
 
         function getCycleTimeForColumn(issues, columnLabel) {

--- a/lib/static/static/templates/metrics.html
+++ b/lib/static/static/templates/metrics.html
@@ -103,6 +103,8 @@
         </div> 
         <div class="statistic-textual-summary">
             {{ statistic.numberOfHistoricalItems }} historical issues, on average, spending {{ statistic.mean.toFixed(1) }} days in progress.
+            Longest: <a href="https://github.com/{{ vm.repo }}/issues/{{ statistic.longestDataPoint.issue.number }}" target="_blank">{{ statistic.longestDataPoint.issue.number }}</a> - taking {{ statistic.longestDataPoint.time }} days,
+            Shortest: <a href="https://github.com/{{ vm.repo }}/issues/{{ statistic.shortestDataPoint.issue.number }}" target="_blank">{{ statistic.shortestDataPoint.issue.number }}</a>  - taking {{ statistic.shortestDataPoint.time }} days
         </div>     
     </div>
   </div>


### PR DESCRIPTION
* Updated the service to include these charts.
* Added longest and shortest data points for reference